### PR TITLE
updating requirement.txt

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -1,5 +1,4 @@
-python>=3.6
-pytorch>=1.8
+torch>=1.8
 numpy
 pandas
 blobfile


### PR DESCRIPTION
The Python package cannot be installed using 'pip' so, removed python and when installing pytorch using 'pip' it is always torch and not pytorch. So, please do the necessary changes to the file.